### PR TITLE
Hide create and modify inputs in the edit merchant page. Also created…

### DIFF
--- a/app/controllers/little_shop_app.rb
+++ b/app/controllers/little_shop_app.rb
@@ -54,7 +54,7 @@ class LittleShopApp < Sinatra::Base
 
   put "/merchants/:id" do |id|
     Merchant.update(id.to_i, params[:merchant])
-    redirect "/merchants/#{id}"
+    redirect "/merchants/#{params[:merchant][:id]}"
   end
 
   get "/merchants/delete/:id" do |id|

--- a/app/views/merchants/edit.erb
+++ b/app/views/merchants/edit.erb
@@ -39,8 +39,8 @@
           <input type="hidden" name="_method"  class="input" value="PUT" />
           <input type='number' name='merchant[id]' style="width: 300px;" class="input" value="<%= @merchant.id %>"/><br/>
           <input type='text' name='merchant[name]' class="input" style="width: 300px;" class="input" value="<%= @merchant.name %>"/><br/>
-          <input type='date' name='merchant[created_at]' class="input" style="width: 300px;" class="input" value="<%= @merchant.created_at %>"/><br/>
-          <input type='date' name='merchant[updated_at]' class="input" style="width: 300px;" class="input" value="<%= @merchant.created_at %>"/><br/>
+          <input type="hidden" name='merchant[created_at]' class="input" style="width: 300px;" class="input" value="<%= @merchant.created_at %>"/><br/>
+          <input type="hidden" name='merchant[updated_at]' class="input" style="width: 300px;" class="input" value="<%= Time.now %>"/><br/>
           <input type='submit'/>
         </form>
        </div>


### PR DESCRIPTION
Yo guys, I made the created_at and updated_at values hidden, and also made it so the updated_at would be the Time.now.

I also realized that if you tried to edit a merchant's ID it would lead you to an error page because the redirect was to the mechant's old ID. I fixed that by changing the redirect to use the new params like so:
redirect "/merchants/#{params[:merchant][:id]}"